### PR TITLE
set decimals of arp and ap statweights per item budget to 2

### DIFF
--- a/website/index.html
+++ b/website/index.html
@@ -4870,9 +4870,9 @@
             let ci95_value = sw.ci95.toFixed(2);
             string += "+10 " + sw.name + " equate <b>" + mean_stat_value + " &plusmn " + ci95_value + "</b> dps";
             if (sw.name === "arpen") {
-                string += " (<b>" + mean_stat_value * 7 + " &plusmn " + ci95_value * 7 + "</b> per 10 item budget)";
+                string += " (<b>" + (mean_stat_value * 7).toFixed(2) + " &plusmn " + (ci95_value * 7).toFixed(2) + "</b> per 10 item budget)";
             } else if (sw.name === "ap") {
-                string += " (<b>" + mean_stat_value * 2 + " &plusmn " + ci95_value * 2 + "</b> per 10 item budget)";
+                string += " (<b>" + (mean_stat_value * 2).toFixed(2) + " &plusmn " + (ci95_value * 2).toFixed(2) + "</b> per 10 item budget)";
             }
             string += ".<br />";
         }


### PR DESCRIPTION
Fixed showing too many decimals on the per-item-budget stat weights, like in the picture below:
![image](https://user-images.githubusercontent.com/12127284/156635260-53767292-648a-419a-bf80-b66b50bdabd5.png)

They will now be limited to 2 decimals like every other stat weight