### PR TITLE
Save and load two handed mode & 2 bugfixes

### DIFF
--- a/website/index.html
+++ b/website/index.html
@@ -1049,7 +1049,7 @@
         <br>
 
         <input type="checkbox" id="do_comparison"
-               onclick="unique_checkboxes('do_comparison', ['normal_mode']);>
+               onclick="unique_checkboxes('do_comparison', ['normal_mode']);">
         <label for="do_comparison"><b>Comparison</b>: Add a configuration file to compa
         re against</label>
         <div class="description" style="display:none" id="compare_div">

--- a/website/index.html
+++ b/website/index.html
@@ -4581,6 +4581,9 @@
             }
         }
 
+        if (document.getElementById("two_hand_mode").checked) {
+            file_content += "two_hand_mode" + " " + "two_hand_mode" + "\n";
+        }
         file_content += "race_dd" + " " + race_string + "\n";
 
         let uriContent = "data:application/octet-stream," + encodeURIComponent(file_content);

--- a/website/js/load_presets.js
+++ b/website/js/load_presets.js
@@ -111,7 +111,7 @@ function load_preraidbis() {
         "fel_leather_gloves", "deathforge_girdle", "midnight_legguards",
         "fel_leather_boots", "band_of_unnatural_forces", "ring_of_arathi_warlords",
         "bloodlust_brooch", "hourglass_of_the_unraveller", "mamas_insurance"];
-    let selected_weapons = ["dragonmaw", "gladiators_slicer", "lionheart_champion"];
+    let selected_weapons = ["dragonmaw_mh", "gladiators_slicer", "lionheart_champion"];
     let selected_enchants = ["ferocity", "greater_vengeance", "+12 agility", "+6 stats", "+12 strength",
         "+15 strength", "nethercobra", "cats_swiftness", "mongoose", "mongoose", "ring_1", "ring_2"];
     let selected_gems = ["+8 crit", "agi critDmg", "helmet_gem3_dd", "neck_gem1_dd", "neck_gem2_dd", "neck_gem3_dd", "+8 crit", "+8 crit", "shoulder_gem3_dd", "+4 crit_+4_str", "back_gem2_dd", "back_gem3_dd",
@@ -146,7 +146,7 @@ function load_p1furybis() {
         "gauntlets_of_martial_perfection", "girdle_of_the_endless_pit", "skulkers_greaves",
         "ironstriders_of_urgency", "ring_of_a_thousand_marks", "shapeshifters_signet",
         "bloodlust_brooch", "dragonspine_trophy", "mamas_insurance"];
-    let selected_weapons = ["dragonmaw", "spiteblade"];
+    let selected_weapons = ["dragonmaw_mh", "spiteblade"];
     let selected_enchants = ["ferocity", "naxxramas", "+12 agility", "+6 stats", "+12 strength",
         "+15 strength", "nethercobra", "cats_swiftness", "mongoose", "mongoose", "ring_1", "ring_2"];
     let selected_gems = ["+8 crit", "agi critDmg", "helmet_gem3_dd", "neck_gem1_dd", "neck_gem2_dd", "neck_gem3_dd", "+8 crit", "+4 crit", "shoulder_gem3_dd", "+4 crit_+4_str", "back_gem2_dd", "back_gem3_dd",
@@ -203,7 +203,7 @@ function load_p2furybisplate() {
         "destroyer_gauntlets", "belt_of_one_hundred_deaths", "leggings_of_murderous_intent",
         "warboots_of_obliteration", "band_of_the_ranger_general", "ring_of_a_thousand_marks",
         "dragonspine_trophy", "tsunami_talisman", "serpent_spine_longbow"];
-    let selected_weapons = ["dragonstrike", "talon_of_azshara"];
+    let selected_weapons = ["dragonstrike_mh", "talon_of_azshara"];
     let selected_enchants = ["ferocity", "naxxramas", "+12 agility", "+6 stats", "+12 strength",
         "+15 strength", "nethercobra", "cats_swiftness", "mongoose", "mongoose", "ring_1", "ring_2"];
     let selected_gems = ["+4 crit", "agi critDmg", "helmet_gem3_dd", "neck_gem1_dd", "neck_gem2_dd", "neck_gem3_dd", "+8 crit", "+4 crit_+4_str", "shoulder_gem3_dd", "+4 crit_+4_str", "back_gem2_dd", "back_gem3_dd",
@@ -222,7 +222,7 @@ function load_p2furybisleather() {
         "gloves_of_the_searing_grip", "belt_of_one_hundred_deaths", "leggings_of_murderous_intent",
         "warboots_of_obliteration", "band_of_the_ranger_general", "ring_of_reciprocity",
         "dragonspine_trophy", "tsunami_talisman", "serpent_spine_longbow"];
-    let selected_weapons = ["dragonstrike", "merciless_gladiators_slicer"];
+    let selected_weapons = ["dragonstrike_mh", "merciless_gladiators_slicer"];
     let selected_enchants = ["ferocity", "naxxramas", "+12 agility", "+6 stats", "+12 strength",
         "+15 strength", "nethercobra", "cats_swiftness", "mongoose", "mongoose", "ring_1", "ring_2"];
     let selected_gems = ["+4 crit", "agi critDmg", "helmet_gem3_dd", "neck_gem1_dd", "neck_gem2_dd", "neck_gem3_dd", "+4 crit_+4_str", "shoulder_gem2_dd","shoulder_gem3_dd", "+4 crit_+4_str", "back_gem2_dd", "back_gem3_dd",
@@ -257,7 +257,7 @@ function load_preraidbismult() {
         "fel_leather_gloves", "deathforge_girdle", "midnight_legguards",
         "fel_leather_boots", "band_of_unnatural_forces", "ring_of_arathi_warlords",
         "bloodlust_brooch", "hourglass_of_the_unraveller", "mamas_insurance"];
-    let selected_weapons = ["dragonmaw", "gladiators_slicer", "lionheart_champion"];
+    let selected_weapons = ["dragonmaw_mh", "gladiators_slicer", "lionheart_champion"];
     let selected_enchants = ["ferocity", "greater_vengeance", "+12 agility", "+6 stats", "+12 strength",
         "+15 strength", "nethercobra", "cats_swiftness", "mongoose", "mongoose", "ring_1", "ring_2"];
     let selected_gems = ["+8 crit", "agi critDmg", "helmet_gem3_dd", "neck_gem1_dd", "neck_gem2_dd", "neck_gem3_dd", "+8 crit", "+8 crit", "shoulder_gem3_dd", "+4 crit_+4_str", "back_gem2_dd", "back_gem3_dd",
@@ -290,7 +290,7 @@ function load_p1furybismult() {
         "gauntlets_of_martial_perfection", "girdle_of_the_endless_pit", "skulkers_greaves",
         "ironstriders_of_urgency", "ring_of_a_thousand_marks", "shapeshifters_signet",
         "bloodlust_brooch", "dragonspine_trophy", "mamas_insurance"];
-    let selected_weapons = ["dragonmaw", "spiteblade"];
+    let selected_weapons = ["dragonmaw_mh", "spiteblade"];
     let selected_enchants = ["ferocity", "naxxramas", "+12 agility", "+6 stats", "+12 strength",
         "+15 strength", "nethercobra", "cats_swiftness", "mongoose", "mongoose", "ring_1", "ring_2"];
     let selected_gems = ["+8 crit", "agi critDmg", "helmet_gem3_dd", "neck_gem1_dd", "neck_gem2_dd", "neck_gem3_dd", "+8 crit", "+4 crit", "shoulder_gem3_dd", "+4 crit_+4_str", "back_gem2_dd", "back_gem3_dd",
@@ -341,7 +341,7 @@ function load_p2furybisplatemult() {
         "destroyer_gauntlets", "belt_of_one_hundred_deaths", "leggings_of_murderous_intent",
         "warboots_of_obliteration", "band_of_the_ranger_general", "ring_of_a_thousand_marks",
         "dragonspine_trophy", "tsunami_talisman", "serpent_spine_longbow"];
-    let selected_weapons = ["dragonstrike", "talon_of_azshara"];
+    let selected_weapons = ["dragonstrike_mh", "talon_of_azshara"];
     let selected_enchants = ["ferocity", "naxxramas", "+12 agility", "+6 stats", "+12 strength",
         "+15 strength", "nethercobra", "cats_swiftness", "mongoose", "mongoose", "ring_1", "ring_2"];
     let selected_gems = ["+4 crit", "agi critDmg", "helmet_gem3_dd", "neck_gem1_dd", "neck_gem2_dd", "neck_gem3_dd", "+8 crit", "+4 crit_+4_str", "shoulder_gem3_dd", "+4 crit_+4_str", "back_gem2_dd", "back_gem3_dd",
@@ -358,7 +358,7 @@ function load_p2furybisleathermult() {
         "gloves_of_the_searing_grip", "belt_of_one_hundred_deaths", "leggings_of_murderous_intent",
         "warboots_of_obliteration", "band_of_the_ranger_general", "ring_of_reciprocity",
         "dragonspine_trophy", "tsunami_talisman", "serpent_spine_longbow"];
-    let selected_weapons = ["dragonstrike", "merciless_gladiators_slicer"];
+    let selected_weapons = ["dragonstrike_mh", "merciless_gladiators_slicer"];
     let selected_enchants = ["ferocity", "naxxramas", "+12 agility", "+6 stats", "+12 strength",
         "+15 strength", "nethercobra", "cats_swiftness", "mongoose", "mongoose", "ring_1", "ring_2"];
     let selected_gems = ["+4 crit", "agi critDmg", "helmet_gem3_dd", "neck_gem1_dd", "neck_gem2_dd", "neck_gem3_dd", "+4 crit_+4_str", "shoulder_gem2_dd","shoulder_gem3_dd", "+4 crit_+4_str", "back_gem2_dd", "back_gem3_dd",

--- a/website/js/load_presets.js
+++ b/website/js/load_presets.js
@@ -24,7 +24,7 @@ function selectElement(id, valueToSelect) {
         } else {
             if (id === valueToSelect) {
                 try {
-                    document.getElementById(id).checked = true;
+                    document.getElementById(id).click();
                 } catch (err) {
                     console.log(err);
                 }


### PR DESCRIPTION
Bugfixes:

- Since Dragonmaw/strike were made one-handed, the presets had the wrong weapon names (missing the _mh suffix) leading to empty mainhand. This has been fixed
- There was an onclick action which was missing the end quote

New stuff:

- If two-handed mode is enabled, `two_hand_mode` will now be saved in the txt file
- When loading a file, instead of setting checked status to true, it will now call the `.click()` function on the checkbox. As a result of that, two-handed mode will now be properly loaded from the txt file