### PR TITLE
change preset buttons into a dropdown

### DIFF
--- a/website/index.html
+++ b/website/index.html
@@ -118,15 +118,27 @@
     <div class="content">
         <div id="armor_single">
             <p class="select-title">Quick-select:</p><br>
-            <button onclick="load_naxxgear()">Naxx gear</button>
-            <button onclick="load_preraidbis()">Babyhoof's Preraid "BiS"</button>
-            <button onclick="load_p1armsbis()">Babyhoof's P1 Arms BiS</button>
-            <button onclick="load_p1furybis()">Babyhoof's P1 Fury BiS</button>
-            <button onclick="load_p2armsbisplate()">Babyhoof's P2 Arms Plate BiS</button>
-            <button onclick="load_p2armsbisleather()">Babyhoof's P2 Arms Leather BiS</button>
-            <button onclick="load_p2furybisplate()">Babyhoof's P2 Fury Plate BiS</button>
-            <button onclick="load_p2furybisleather()">Babyhoof's P2 Fury Leather BiS</button>
-            <br><br>
+            <select id="preset">
+                <option value="" selected></option>
+                <optgroup label="Phase 3"></optgroup>
+                <optgroup label="Phase 2">
+                    <option value="load_p2armsbisplate()">Babyhoof's P2 Arms Plate BiS</option>
+                    <option value="load_p2armsbisleather()">Babyhoof's P2 Arms Leather BiS</option>
+                    <option value="load_p2furybisplate()">Babyhoof's P2 Fury Plate BiS</option>
+                    <option value="load_p2furybisleather()">Babyhoof's P2 Fury Leather BiS</option>
+                </optgroup>
+                <optgroup label="Phase 1">
+                    <option value="load_p1armsbis()">Babyhoof's P1 Arms BiS</option>
+                    <option value="load_p1furybis()">Babyhoof's P1 Fury BiS</option>
+                </optgroup>
+                <optgroup label="Pre-Raid">
+                    <option value="load_preraidbis()"> Babyhoof's Preraid BiS</option>
+                    <option value="load_naxxgear()"> Naxx Gear</option>
+                </optgroup>
+            </select>
+            <button onclick="load_preset()">Apply Preset</button>
+            <br>
+            <br>
             <!--armor begin1-->
             <span class="left_select">helmet</span><span class="middle_select">neck</span><span class="right_select">shoulder</span><br>
             <select id="helmet_dd" class="item-select">

--- a/website/js/load_presets.js
+++ b/website/js/load_presets.js
@@ -88,6 +88,13 @@ function select_loadout_mult(selected_items, selected_weapons, selected_enchants
     }
 }
 
+function load_preset() {
+    var presetEl = document.getElementById('preset');
+    var presetVal = presetEl.options[presetEl.selectedIndex].value;
+    var evalFunc = Function("return (" + presetVal + ");");
+    evalFunc();
+}
+
 
 function load_naxxgear() {
     let selected_items = ["lionheart_helm", "stormrages_talisman_of_seething", "conquerors_spaulders",
@@ -111,7 +118,7 @@ function load_preraidbis() {
         "fel_leather_gloves", "deathforge_girdle", "midnight_legguards",
         "fel_leather_boots", "band_of_unnatural_forces", "ring_of_arathi_warlords",
         "bloodlust_brooch", "hourglass_of_the_unraveller", "mamas_insurance"];
-    let selected_weapons = ["dragonmaw", "gladiators_slicer", "lionheart_champion"];
+    let selected_weapons = ["dragonmaw_mh", "gladiators_slicer", "lionheart_champion"];
     let selected_enchants = ["ferocity", "greater_vengeance", "+12 agility", "+6 stats", "+12 strength",
         "+15 strength", "nethercobra", "cats_swiftness", "mongoose", "mongoose", "ring_1", "ring_2"];
     let selected_gems = ["+8 crit", "agi critDmg", "helmet_gem3_dd", "neck_gem1_dd", "neck_gem2_dd", "neck_gem3_dd", "+8 crit", "+8 crit", "shoulder_gem3_dd", "+4 crit_+4_str", "back_gem2_dd", "back_gem3_dd",
@@ -146,7 +153,7 @@ function load_p1furybis() {
         "gauntlets_of_martial_perfection", "girdle_of_the_endless_pit", "skulkers_greaves",
         "ironstriders_of_urgency", "ring_of_a_thousand_marks", "shapeshifters_signet",
         "bloodlust_brooch", "dragonspine_trophy", "mamas_insurance"];
-    let selected_weapons = ["dragonmaw", "spiteblade"];
+    let selected_weapons = ["dragonmaw_mh", "spiteblade"];
     let selected_enchants = ["ferocity", "naxxramas", "+12 agility", "+6 stats", "+12 strength",
         "+15 strength", "nethercobra", "cats_swiftness", "mongoose", "mongoose", "ring_1", "ring_2"];
     let selected_gems = ["+8 crit", "agi critDmg", "helmet_gem3_dd", "neck_gem1_dd", "neck_gem2_dd", "neck_gem3_dd", "+8 crit", "+4 crit", "shoulder_gem3_dd", "+4 crit_+4_str", "back_gem2_dd", "back_gem3_dd",
@@ -203,7 +210,7 @@ function load_p2furybisplate() {
         "destroyer_gauntlets", "belt_of_one_hundred_deaths", "leggings_of_murderous_intent",
         "warboots_of_obliteration", "band_of_the_ranger_general", "ring_of_a_thousand_marks",
         "dragonspine_trophy", "tsunami_talisman", "serpent_spine_longbow"];
-    let selected_weapons = ["dragonstrike", "talon_of_azshara"];
+    let selected_weapons = ["dragonstrike_mh", "talon_of_azshara"];
     let selected_enchants = ["ferocity", "naxxramas", "+12 agility", "+6 stats", "+12 strength",
         "+15 strength", "nethercobra", "cats_swiftness", "mongoose", "mongoose", "ring_1", "ring_2"];
     let selected_gems = ["+4 crit", "agi critDmg", "helmet_gem3_dd", "neck_gem1_dd", "neck_gem2_dd", "neck_gem3_dd", "+8 crit", "+4 crit_+4_str", "shoulder_gem3_dd", "+4 crit_+4_str", "back_gem2_dd", "back_gem3_dd",
@@ -222,7 +229,7 @@ function load_p2furybisleather() {
         "gloves_of_the_searing_grip", "belt_of_one_hundred_deaths", "leggings_of_murderous_intent",
         "warboots_of_obliteration", "band_of_the_ranger_general", "ring_of_reciprocity",
         "dragonspine_trophy", "tsunami_talisman", "serpent_spine_longbow"];
-    let selected_weapons = ["dragonstrike", "merciless_gladiators_slicer"];
+    let selected_weapons = ["dragonstrike_mh", "merciless_gladiators_slicer"];
     let selected_enchants = ["ferocity", "naxxramas", "+12 agility", "+6 stats", "+12 strength",
         "+15 strength", "nethercobra", "cats_swiftness", "mongoose", "mongoose", "ring_1", "ring_2"];
     let selected_gems = ["+4 crit", "agi critDmg", "helmet_gem3_dd", "neck_gem1_dd", "neck_gem2_dd", "neck_gem3_dd", "+4 crit_+4_str", "shoulder_gem2_dd","shoulder_gem3_dd", "+4 crit_+4_str", "back_gem2_dd", "back_gem3_dd",
@@ -257,7 +264,7 @@ function load_preraidbismult() {
         "fel_leather_gloves", "deathforge_girdle", "midnight_legguards",
         "fel_leather_boots", "band_of_unnatural_forces", "ring_of_arathi_warlords",
         "bloodlust_brooch", "hourglass_of_the_unraveller", "mamas_insurance"];
-    let selected_weapons = ["dragonmaw", "gladiators_slicer", "lionheart_champion"];
+    let selected_weapons = ["dragonmaw_mh", "gladiators_slicer", "lionheart_champion"];
     let selected_enchants = ["ferocity", "greater_vengeance", "+12 agility", "+6 stats", "+12 strength",
         "+15 strength", "nethercobra", "cats_swiftness", "mongoose", "mongoose", "ring_1", "ring_2"];
     let selected_gems = ["+8 crit", "agi critDmg", "helmet_gem3_dd", "neck_gem1_dd", "neck_gem2_dd", "neck_gem3_dd", "+8 crit", "+8 crit", "shoulder_gem3_dd", "+4 crit_+4_str", "back_gem2_dd", "back_gem3_dd",
@@ -290,7 +297,7 @@ function load_p1furybismult() {
         "gauntlets_of_martial_perfection", "girdle_of_the_endless_pit", "skulkers_greaves",
         "ironstriders_of_urgency", "ring_of_a_thousand_marks", "shapeshifters_signet",
         "bloodlust_brooch", "dragonspine_trophy", "mamas_insurance"];
-    let selected_weapons = ["dragonmaw", "spiteblade"];
+    let selected_weapons = ["dragonmaw_mh", "spiteblade"];
     let selected_enchants = ["ferocity", "naxxramas", "+12 agility", "+6 stats", "+12 strength",
         "+15 strength", "nethercobra", "cats_swiftness", "mongoose", "mongoose", "ring_1", "ring_2"];
     let selected_gems = ["+8 crit", "agi critDmg", "helmet_gem3_dd", "neck_gem1_dd", "neck_gem2_dd", "neck_gem3_dd", "+8 crit", "+4 crit", "shoulder_gem3_dd", "+4 crit_+4_str", "back_gem2_dd", "back_gem3_dd",
@@ -341,7 +348,7 @@ function load_p2furybisplatemult() {
         "destroyer_gauntlets", "belt_of_one_hundred_deaths", "leggings_of_murderous_intent",
         "warboots_of_obliteration", "band_of_the_ranger_general", "ring_of_a_thousand_marks",
         "dragonspine_trophy", "tsunami_talisman", "serpent_spine_longbow"];
-    let selected_weapons = ["dragonstrike", "talon_of_azshara"];
+    let selected_weapons = ["dragonstrike_mh", "talon_of_azshara"];
     let selected_enchants = ["ferocity", "naxxramas", "+12 agility", "+6 stats", "+12 strength",
         "+15 strength", "nethercobra", "cats_swiftness", "mongoose", "mongoose", "ring_1", "ring_2"];
     let selected_gems = ["+4 crit", "agi critDmg", "helmet_gem3_dd", "neck_gem1_dd", "neck_gem2_dd", "neck_gem3_dd", "+8 crit", "+4 crit_+4_str", "shoulder_gem3_dd", "+4 crit_+4_str", "back_gem2_dd", "back_gem3_dd",
@@ -358,7 +365,7 @@ function load_p2furybisleathermult() {
         "gloves_of_the_searing_grip", "belt_of_one_hundred_deaths", "leggings_of_murderous_intent",
         "warboots_of_obliteration", "band_of_the_ranger_general", "ring_of_reciprocity",
         "dragonspine_trophy", "tsunami_talisman", "serpent_spine_longbow"];
-    let selected_weapons = ["dragonstrike", "merciless_gladiators_slicer"];
+    let selected_weapons = ["dragonstrike_mh", "merciless_gladiators_slicer"];
     let selected_enchants = ["ferocity", "naxxramas", "+12 agility", "+6 stats", "+12 strength",
         "+15 strength", "nethercobra", "cats_swiftness", "mongoose", "mongoose", "ring_1", "ring_2"];
     let selected_gems = ["+4 crit", "agi critDmg", "helmet_gem3_dd", "neck_gem1_dd", "neck_gem2_dd", "neck_gem3_dd", "+4 crit_+4_str", "shoulder_gem2_dd","shoulder_gem3_dd", "+4 crit_+4_str", "back_gem2_dd", "back_gem3_dd",


### PR DESCRIPTION
This moves the pre-set buttons from individual buttons into a dropdown, to clean up the UI.

I'll try to add the Phase 3 sets in soon if this is still open, otherwise I'll make a new PR.

This also includes lordblackadder's change to add the "_mh" prefix and fix Dragonstrike/Dragonmaw selection in the presets.