### PR TITLE
Wrong checkbox target for armor pen label

### DIFF
--- a/website/index.html
+++ b/website/index.html
@@ -4322,7 +4322,7 @@
         <label for="stat_weight_haste"> +10 Haste rating.</label><br>
 
         <input type="checkbox" id="stat_weight_arpen">
-        <label for="stat_weight_haste"> +10 Armor penetration.</label><br>
+        <label for="stat_weight_arpen"> +10 Armor penetration.</label><br>
 
         <input type="checkbox" id="stat_weight_bonus_damage">
         <label for="stat_weight_bonus_damage"> +10 Bonus damage ("+1 Weapon damage").</label><br>


### PR DESCRIPTION
Checks the wrong checkbox when click on armor pen label